### PR TITLE
Change default push URL on config/mpesa-push.php

### DIFF
--- a/config/mpesa-push.php
+++ b/config/mpesa-push.php
@@ -5,7 +5,7 @@ return [
     /**
      * Request URL.
      */
-    'endpoint' => env('TZ_MPESA_PUSH_ENDPOINT', 'https://broker2.ipg.tz.vodafone.com:30010/iPG/b2c/ussd_push'),
+    'endpoint' => env('TZ_MPESA_PUSH_ENDPOINT', 'https://broker2.ipg.vodacom.co.tz:30010/iPG/b2c/ussd_push'),
 
     /**
      * Path to Vodacom Certificate Authority (CA) Root certificate.


### PR DESCRIPTION
Changes domain name on default push URL to `broker2.ipg.vodacom.co.tz` instead of the previous `broker2.ipg.tz.vodafone.com`